### PR TITLE
chore: Update BroadcastNotificationService oc: 4509

### DIFF
--- a/projects/pap/src/app/features/push-notification/push-notification-page.component.ts
+++ b/projects/pap/src/app/features/push-notification/push-notification-page.component.ts
@@ -1,10 +1,9 @@
-import {Component, OnInit, ViewEncapsulation} from '@angular/core';
-import {Observable} from 'rxjs';
+import {ChangeDetectorRef, Component, NgZone, OnInit, ViewEncapsulation} from '@angular/core';
+import {Observable, Subscription} from 'rxjs';
 import {PushNotification} from './push-notification.model';
 import {Store} from '@ngrx/store';
-import {pushNotifications} from './state/push-notification.selectors';
-import {filter, map, take} from 'rxjs/operators';
-import {removeAllDeliveredNotifications} from './state/push-notification.actions';
+import {firstNotificationId, pushNotifications} from './state/push-notification.selectors';
+import {loadPushNotification, removeAllDeliveredNotifications} from './state/push-notification.actions';
 
 @Component({
   selector: 'pap-push-notification-page',
@@ -13,18 +12,23 @@ import {removeAllDeliveredNotifications} from './state/push-notification.actions
   encapsulation: ViewEncapsulation.None,
 })
 export class PushNotificationsPageComponent implements OnInit {
-  firstNotificationId$: Observable<number>;
-  pushNotifications$: Observable<PushNotification[] | undefined> =
-    this._store.select(pushNotifications);
+  private _firstNotificationIdSub: Subscription = Subscription.EMPTY;
+  private _pushNotificationsSub: Subscription = Subscription.EMPTY;
 
-  constructor(private _store: Store) {}
+  firstNotificationId$: Observable<number | undefined> = this._store.select(firstNotificationId);
+  pushNotifications$: Observable<PushNotification[] | undefined> = this._store.select(pushNotifications);
+
+  constructor(private _store: Store, private _cdr: ChangeDetectorRef, private _ngZone: NgZone) {}
+
+  ngOnDestroy(): void {
+    this._pushNotificationsSub.unsubscribe();
+    this._firstNotificationIdSub.unsubscribe();
+  }
 
   ngOnInit(): void {
     this._store.dispatch(removeAllDeliveredNotifications());
-    this.firstNotificationId$ = this.pushNotifications$.pipe(
-      filter(notifications => !!notifications && notifications.length > 0),
-      take(1),
-      map(notifications => notifications![0].id),
-    );
+    this._store.dispatch(loadPushNotification());
+    this._pushNotificationsSub = this.pushNotifications$.subscribe(() => this._ngZone.run(() => this._cdr.detectChanges()));
+    this._firstNotificationIdSub = this.firstNotificationId$.subscribe(() => this._ngZone.run(() => this._cdr.detectChanges()));
   }
 }

--- a/projects/pap/src/app/features/push-notification/state/push-notification.reducer.ts
+++ b/projects/pap/src/app/features/push-notification/state/push-notification.reducer.ts
@@ -16,6 +16,7 @@ export const pushNotificationFeatureKey = 'push-notification';
 export interface PushNotificationState {
   deliveredNotifications?: PushNotificationSchema[];
   error: string;
+  firstNotificationId?: number;
   pushNotifications?: PushNotification[];
 }
 
@@ -31,6 +32,7 @@ export const reducer = createReducer(
   on(loadPushNotificationSuccess, (state, {pushNotifications}) => ({
     ...state,
     pushNotifications,
+    firstNotificationId: pushNotifications?.[0]?.id,
   })),
   on(loadPushNotificationFailure, (state, {error}) => ({
     ...state,

--- a/projects/pap/src/app/features/push-notification/state/push-notification.selectors.ts
+++ b/projects/pap/src/app/features/push-notification/state/push-notification.selectors.ts
@@ -16,3 +16,7 @@ export const deliveredNotifications = createSelector(
 export const hasDeliveredNotifications = createSelector(deliveredNotifications, dnotifications => {
   return dnotifications && dnotifications.length > 0;
 });
+export const firstNotificationId = createSelector(
+  selectPushNotificationState,
+  state => state.firstNotificationId,
+);

--- a/projects/pap/src/app/shared/services/broadcast-notification.service.ts
+++ b/projects/pap/src/app/shared/services/broadcast-notification.service.ts
@@ -49,11 +49,13 @@ export class BroadcastNotificationService {
             const data = notification.notification.data;
             switch (data.page_on_click) {
               case '/push-notification':
-                this._store.dispatch(loadPushNotification());
+                this._router.navigate(['/push-notification']);
                 break;
               case '/dusty-man-reports':
               case '/reports':
-                this._navigateToReportsPage(data.page_on_click, data.ticket_id);
+                if(data.ticket_id) {
+                  this._navigateToReportsPage(data.page_on_click, +data.ticket_id);
+                }
                 break;
             }
 
@@ -90,18 +92,18 @@ export class BroadcastNotificationService {
     return from(PushNotifications.removeAllDeliveredNotifications());
   }
 
-  private _navigateToReportsPage(path: string, ticketId: number | null): void {
+  private _navigateToReportsPage(path: string, ticketId: number): void {
     console.log('in _navigateToReportsPage');
     this._store.dispatch(loadTickets());
     this.selectReports$
       .pipe(
-        filter(r => !!r && r.length > 0),
+        filter(r => !!r && r.length > 0 && !!r.find(t => t.id == ticketId)),
         take(1),
       )
       .subscribe(d => {
-        this._store.dispatch(selectTicketById({id: ticketId!}));
+        this._store.dispatch(selectTicketById({id: ticketId}));
         this._ngZone.run(() => {
-          this._router.navigate([path, ticketId ?? null]);
+          this._router.navigate([path, ticketId]);
         });
       });
   }


### PR DESCRIPTION
- Changed the dispatch action to navigate to '/push-notification' instead of loading push notification
- Added a condition to navigate to reports page only if ticket_id is present
- Updated the _navigateToReportsPage method to accept a non-null ticketId parameter and filter reports based on the selected ticket

chore: add firstNotificationId to PushNotificationState

- Added the property `firstNotificationId` to the `PushNotificationState` interface.
- Updated the reducer to set `firstNotificationId` as the id of the first push notification in the state.
- Added a new selector `firstNotificationId` to retrieve the value of `firstNotificationId` from the state.

chore: Update push-notification-page.component.ts

- Import ChangeDetectorRef and NgZone from '@angular/core'
- Import Subscription from 'rxjs'
- Update the imports for pushNotifications and removeAllDeliveredNotifications
- Add private variables for _firstNotificationIdSub and _pushNotificationsSub
- Update the type of firstNotificationId$ to Observable<number | undefined>
- Update the type of pushNotifications$ to Observable<PushNotification[] | undefined>
- Add ngOnDestroy method to unsubscribe from subscriptions
- Dispatch removeAllDeliveredNotifications action in ngOnInit
- Dispatch loadPushNotification action in ngOnInit
- Subscribe to pushNotifications$ and call detectChanges in _ngZone.run()
- Subscribe to firstNotificationId$ and call detectChanges in _ngZone.run()
