### PR TITLE
fix(oc:8045): race condition GPS — dispatch setMarker prima di setPosition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,10 @@ ng serve             # dev server su localhost:8100
 
 ## Feature disponibili
 
-| Feature | Ticket | Moduli toccati | Note |
-|---|---|---|---|
-| Fix race condition GPS in getLocation() | oc:8045 | `location.component.ts`, `location.component.spec.ts`, `report-ticket.component.spec.ts`, `company.selectors.spec.ts` | Swap 2 righe in getLocation(); 2 test di regressione per Caso 1 e Caso 2 |
-| Revisione test suite CI headless | oc:7991 | `karma.conf.js`, `angular.json`, `package.json`, `cypress/e2e/**`, `form.component.html`, `first-step.component.html`, `second-step.component.ts` | Karma CI headless + script test:ci; tutti i test Cypress corretti e funzionanti |
+| Feature                                 | Ticket  | Moduli toccati                                                                                                                                    | Note                                                                            |
+| --------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Fix race condition GPS in getLocation() | oc:8045 | `location.component.ts`, `location.component.spec.ts`, `report-ticket.component.spec.ts`, `company.selectors.spec.ts`                             | Swap 2 righe in getLocation(); 2 test di regressione per Caso 1 e Caso 2        |
+| Revisione test suite CI headless        | oc:7991 | `karma.conf.js`, `angular.json`, `package.json`, `cypress/e2e/**`, `form.component.html`, `first-step.component.html`, `second-step.component.ts` | Karma CI headless + script test:ci; tutti i test Cypress corretti e funzionanti |
 
 ## Decisioni architetturali
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,16 @@ ng serve             # dev server su localhost:8100
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Fix race condition GPS in getLocation() | oc:8045 | `location.component.ts`, `location.component.spec.ts`, `report-ticket.component.spec.ts`, `company.selectors.spec.ts` | Swap 2 righe in getLocation(); 2 test di regressione per Caso 1 e Caso 2 |
 | Revisione test suite CI headless | oc:7991 | `karma.conf.js`, `angular.json`, `package.json`, `cypress/e2e/**`, `form.component.html`, `first-step.component.html`, `second-step.component.ts` | Karma CI headless + script test:ci; tutti i test Cypress corretti e funzionanti |
 
 ## Decisioni architetturali
+
+### Fix race condition GPS (oc:8045)
+
+- **Ordine dispatch/setPosition in `getLocation()`**: `dispatch(setMarker({coords}))` deve avvenire **prima** di `setPosition(coords)`. `setPosition` legge `currentZone$` con `take(1)` in modo sincrono — se il marker non è ancora aggiornato nello store la zona è quella del marker precedente (o null). Il flusso `clickOnMap` in `map.component.ts` aveva già l'ordine corretto.
+- **Test con spy su `store.dispatch`**: i test di `getLocation()` non usano solo `overrideSelector` statico, ma aggiornano il selector dentro lo spy del dispatch. Questo rende il test sensibile all'ordine: con le righe invertite il test fallisce perché `setPosition` legge il selector prima che venga aggiornato dal dispatch.
+- **Selector pollution fix**: `report-ticket.component.spec.ts` ora chiama `store.resetSelectors()` in `afterEach` — senza di esso il valore mockato di `selectCompanyProperties` persisteva globalmente sulla funzione selector (chiusura `overrideResult` in `defaultMemoize` di NgRx). `company.selectors.spec.ts` ora chiama `clearResult()` in `beforeEach` per essere ermetico indipendentemente dall'ordine di esecuzione.
 
 ### Revisione test suite (oc:7991)
 

--- a/docs/features/8045-race-condition-gps/notes.md
+++ b/docs/features/8045-race-condition-gps/notes.md
@@ -1,0 +1,23 @@
+> Ticket: oc:8045
+
+# Notes — Race condition su geolocalizzazione GPS
+
+## Deviazioni dal piano
+
+Nessuna deviazione sul fix principale. Il piano prevedeva 2 file modificati; la suite di test ha richiesto 2 file aggiuntivi (vedi sezione Decisioni).
+
+## Bug trovati
+
+**Selector pollution preesistente** (`report-ticket.component.spec.ts`): il test chiamava `store.overrideSelector(selectCompanyProperties, ...)` senza `afterEach(() => store.resetSelectors())`. Il valore mockato persisteva globalmente sulla funzione selector (chiusura `overrideResult` in `defaultMemoize`). I nuovi test hanno cambiato qualcosa nella lifecycle del MockStore che ha esposto la fragilità: `company.selectors.spec.ts` ha iniziato a ricevere `{enableExludeInProgress: false}` (leftover del primo test di report-ticket) invece di `{true}`. Prima passava per puro accidente di ordinamento.
+
+## Decisioni
+
+**Scope esteso a `report-ticket.component.spec.ts` e `company.selectors.spec.ts`**: i 2 file non erano nel piano originale, ma la suite non poteva essere dichiarata verde senza fixare il pollution preesistente. Entrambi i fix seguono la best practice NgRx (`resetSelectors()` in `afterEach`, `clearResult()` in `beforeEach` per test che invocano il selector direttamente).
+
+**Design test con `store.dispatch` spy**: il test non verifica solo l'outcome (zone_id/city) ma anche l'invariante di ordinamento — lo spy su `store.dispatch` aggiorna `overrideSelector` solo dopo il dispatch di `setMarker`, quindi il test fallisce se le righe vengono reinvertite. Questo fu scelto dopo la Challenge adversariale che evidenziò come test basati su solo `overrideSelector` non falsifichino la race condition.
+
+## Follow-up
+
+- **Double-tap GPS non-issue**: se l'utente preme GPS due volte rapidamente, entrambe le callback GPS restituiscono le stesse coordinate (utente da fermo). La zona calcolata è identica — non c'è corruzione di dati. Non richiede fix.
+- **`try/catch` asincrono inutile**: il blocco `try/catch` in `getLocation()` cattura solo eccezioni sincrone; la callback di errore di `getCurrentPosition` (permesso GPS negato, GPS non disponibile) viene ignorata silenziosamente. Il form resta in stato indeterminato senza feedback. Bug preesistente, da indirizzare in ticket separato.
+- **Sovrascrittura `zone_id` non serializzata**: in `setPosition()` ci sono due scritture su `zone_id` non serializzate — `currentZone$.pipe(take(1))` (sincrono) e `getAddress()` asincrono via `setAddress(res)`. Se `res.zone_id` è presente, può sovrascrivere il valore corretto impostato dal selector. Bug preesistente, da indirizzare in ticket separato.

--- a/docs/features/8045-race-condition-gps/overview.md
+++ b/docs/features/8045-race-condition-gps/overview.md
@@ -1,0 +1,35 @@
+> Ticket: oc:8045
+
+# Race condition su geolocalizzazione GPS: zone_id e comune errati o errore spurio
+
+## Cosa cambia
+
+`getLocation()` in `location.component.ts` dispatcha `setMarker` **prima** di chiamare `setPosition`, allineandosi all'ordine già corretto usato dal flusso click-su-mappa.
+
+## Perché
+
+`setPosition()` legge `currentZone$` con `take(1)` in modo sincrono: al momento della lettura il selector calcola la zona sulle coordinate di `currentMarkerCoords` presenti nello store. Con il vecchio ordine, `setMarker` non era ancora stato dispatchato, quindi la zona veniva calcolata sulle coordinate del marker precedente (Caso 1) o su coordinate vuote/`[0,0]` (Caso 2), causando rispettivamente dato corrotto silenzioso o errore spurio che bloccava il form.
+
+## Requisiti
+
+- [ ] In `getLocation()`, `dispatch(setMarker({coords}))` viene eseguito **prima** di `setPosition(coords)`
+- [ ] Test unitario: `getLocation()` con marker iniziale vuoto non produce errore `incorrect` sul campo `location` (Caso 2 — errore spurio); il test usa spy su `store.dispatch` per aggiornare `overrideSelector` solo dopo il dispatch di `setMarker`, così fallisce se le righe vengono reinvertite
+- [ ] Test unitario: `getLocation()` con marker precedente in zona diversa imposta `zone_id` e `city` dalle coordinate GPS nuove, non da quelle vecchie (Caso 1 — dato corrotto silenzioso); stesso pattern di spy
+
+## Rischi
+
+- **Nessuna regressione su `mapClick()`**: `mapClick()` chiama già solo `setPosition()` senza dispatchare `setMarker` — il dispatch arriva da `clickOnMap` in `map.component.ts` prima che venga emesso `genericClickEvt`. Il fix non tocca questo flusso.
+- **`take(1)` sincrono**: il fix funziona perché NgRx aggiorna lo stato dello store sincronamente al dispatch. Se in futuro il reducer diventasse asincrono, il contratto di ordinamento andrebbe rivisto. I test fissano questo comportamento atteso.
+
+## Out of scope
+
+- Refactoring di `mapClick()` per aggiungere il dispatch (il contratto attuale è corretto, garantito dai test)
+- Modifiche a `map.component.ts` o ad altri componenti
+- Aggiunta di commenti inline per documentare il contratto di ordinamento
+
+## Moduli toccati
+
+| File | Azione |
+|---|---|
+| `projects/pap/src/app/shared/form/location/location.component.ts` | swap 2 righe in `getLocation()` (riga 106–107) |
+| `projects/pap/src/app/shared/form/location/location.component.spec.ts` | aggiunta `describe('getLocation()')` con 2 test |

--- a/docs/features/8045-race-condition-gps/overview.md
+++ b/docs/features/8045-race-condition-gps/overview.md
@@ -29,7 +29,7 @@
 
 ## Moduli toccati
 
-| File | Azione |
-|---|---|
-| `projects/pap/src/app/shared/form/location/location.component.ts` | swap 2 righe in `getLocation()` (riga 106–107) |
+| File                                                                   | Azione                                          |
+| ---------------------------------------------------------------------- | ----------------------------------------------- |
+| `projects/pap/src/app/shared/form/location/location.component.ts`      | swap 2 righe in `getLocation()` (riga 106–107)  |
 | `projects/pap/src/app/shared/form/location/location.component.spec.ts` | aggiunta `describe('getLocation()')` con 2 test |

--- a/docs/features/8045-race-condition-gps/plan.md
+++ b/docs/features/8045-race-condition-gps/plan.md
@@ -1,0 +1,135 @@
+> Ticket: oc:8045
+
+# Plan — Race condition su geolocalizzazione GPS
+
+## Step 1 — Crea branch
+
+```bash
+git checkout -b fix/oc-8045-race-condition-gps
+```
+
+---
+
+## Step 2 — Fix `location.component.ts`
+
+**File:** `projects/pap/src/app/shared/form/location/location.component.ts`
+
+Nella callback di `getLocation()` (righe 104–108), invertire le due righe: dispatchare `setMarker` **prima** di chiamare `setPosition`.
+
+**Prima (ordine errato):**
+```ts
+navigator.geolocation.getCurrentPosition(location => {
+  const coords = [location.coords.longitude, location.coords.latitude] as [number, number];
+  this.setPosition(coords);
+  this._store.dispatch(setMarker({coords}));
+});
+```
+
+**Dopo (ordine corretto):**
+```ts
+navigator.geolocation.getCurrentPosition(location => {
+  const coords = [location.coords.longitude, location.coords.latitude] as [number, number];
+  this._store.dispatch(setMarker({coords}));
+  this.setPosition(coords);
+});
+```
+
+---
+
+## Step 3 — Aggiungi test in `location.component.spec.ts`
+
+**File:** `projects/pap/src/app/shared/form/location/location.component.spec.ts`
+
+Aggiungere un nuovo blocco `describe('getLocation()')` dopo il blocco `describe('setAddress() con "altro"')` esistente.
+
+I test usano `spyOn(store, 'dispatch').and.callFake(...)` per aggiornare `overrideSelector` solo dopo che `setMarker` viene dispatchato — così il test **fallisce** se le righe vengono reinvertite (perché `currentZone$` sarebbe ancora `null` al momento della lettura).
+
+```ts
+describe('getLocation()', () => {
+  beforeEach(() => {
+    spyOn(navigator.geolocation, 'getCurrentPosition').and.callFake((cb: any) => {
+      cb({coords: {longitude: 11.25, latitude: 43.77}});
+    });
+  });
+
+  it('non produce errore spurio quando non esiste un marker precedente (Caso 2)', async () => {
+    store.overrideSelector(currentZone as any, null);
+    store.refreshState();
+
+    spyOn(store, 'dispatch').and.callFake((action: any) => {
+      if (action.type === '[Map] set current marker') {
+        store.overrideSelector(currentZone as any, mockZone);
+        store.refreshState();
+      }
+    });
+
+    await component.getLocation();
+
+    expect(component.form.get('location')!.errors).toBeNull();
+    expect(component.form.get('zone_id')!.value).toBe(42);
+  });
+
+  it('usa zone_id e city delle coordinate GPS nuove, non del marker precedente (Caso 1)', async () => {
+    const oldZone = {
+      type: 'Feature',
+      geometry: {coordinates: [], type: 'MultiPolygon'},
+      properties: {id: 99, comune: 'Vecchio', availableUserTypes: [], types: [], url: ''},
+    };
+    store.overrideSelector(currentZone as any, oldZone);
+    store.refreshState();
+
+    spyOn(store, 'dispatch').and.callFake((action: any) => {
+      if (action.type === '[Map] set current marker') {
+        store.overrideSelector(currentZone as any, mockZone);
+        store.refreshState();
+      }
+    });
+
+    await component.getLocation();
+
+    expect(component.form.get('zone_id')!.value).toBe(42);
+    expect(component.form.get('city')!.value).toBe('Firenze');
+  });
+});
+```
+
+---
+
+## Step 4 — Verifica test
+
+```bash
+npm run test:ci
+```
+
+Tutti i test devono passare, inclusi i due nuovi.
+
+---
+
+## Step 5 — Scrivi `notes.md`
+
+Creare `docs/features/8045-race-condition-gps/notes.md` con le deviazioni e i follow-up emersi dalla Challenge.
+
+---
+
+## Step 6 — Aggiorna `CLAUDE.md`
+
+Aggiornare le sezioni "Feature disponibili" e "Decisioni architetturali" del `CLAUDE.md` radice.
+
+---
+
+## Step 7 — Commit e PR
+
+```bash
+git add projects/pap/src/app/shared/form/location/location.component.ts
+git add projects/pap/src/app/shared/form/location/location.component.spec.ts
+git add docs/features/8045-race-condition-gps/
+```
+
+Commit message:
+```
+fix(oc:8045): correggi race condition GPS in getLocation() — dispatch setMarker prima di setPosition
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+Aprire PR verso **`develop`**.

--- a/docs/features/8045-race-condition-gps/plan.md
+++ b/docs/features/8045-race-condition-gps/plan.md
@@ -17,6 +17,7 @@ git checkout -b fix/oc-8045-race-condition-gps
 Nella callback di `getLocation()` (righe 104–108), invertire le due righe: dispatchare `setMarker` **prima** di chiamare `setPosition`.
 
 **Prima (ordine errato):**
+
 ```ts
 navigator.geolocation.getCurrentPosition(location => {
   const coords = [location.coords.longitude, location.coords.latitude] as [number, number];
@@ -26,6 +27,7 @@ navigator.geolocation.getCurrentPosition(location => {
 ```
 
 **Dopo (ordine corretto):**
+
 ```ts
 navigator.geolocation.getCurrentPosition(location => {
   const coords = [location.coords.longitude, location.coords.latitude] as [number, number];
@@ -126,6 +128,7 @@ git add docs/features/8045-race-condition-gps/
 ```
 
 Commit message:
+
 ```
 fix(oc:8045): correggi race condition GPS in getLocation() — dispatch setMarker prima di setPosition
 

--- a/projects/pap/src/app/features/report-ticket/report-ticket.component.spec.ts
+++ b/projects/pap/src/app/features/report-ticket/report-ticket.component.spec.ts
@@ -22,10 +22,7 @@ describe('ReportTicketComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [ReportTicketComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      providers: [
-        {provide: NavController, useValue: {pop: () => undefined}},
-        provideMockStore(),
-      ],
+      providers: [{provide: NavController, useValue: {pop: () => undefined}}, provideMockStore()],
     }).compileComponents();
 
     store = TestBed.inject(MockStore);
@@ -61,7 +58,10 @@ describe('ReportTicketComponent', () => {
   });
 
   it('should expose form$ Observable that emits backend config when store has configs', () => {
-    const backendConf: TicketFormConf = {...reportTicketForm, finalMessage: 'Backend report message'};
+    const backendConf: TicketFormConf = {
+      ...reportTicketForm,
+      finalMessage: 'Backend report message',
+    };
     // Override the base selector so all instances of selectTicketFormConfByType('report') react
     store.overrideSelector(selectTicketFormsConfigs as any, {report: backendConf});
     store.refreshState();
@@ -88,4 +88,3 @@ describe('ReportTicketComponent', () => {
     expect(result).toEqual(reportTicketForm);
   });
 });
-

--- a/projects/pap/src/app/features/report-ticket/report-ticket.component.spec.ts
+++ b/projects/pap/src/app/features/report-ticket/report-ticket.component.spec.ts
@@ -33,6 +33,10 @@ describe('ReportTicketComponent', () => {
     component = fixture.componentInstance;
   });
 
+  afterEach(() => {
+    store.resetSelectors();
+  });
+
   it('should dispatch loadCalendars WITHOUT exclude_in_progress when property is false/undefined', () => {
     store.overrideSelector(selectCompanyProperties as any, {enableExludeInProgress: false});
     const dispatchSpy = spyOn(store, 'dispatch');

--- a/projects/pap/src/app/shared/form/location/location.component.spec.ts
+++ b/projects/pap/src/app/shared/form/location/location.component.spec.ts
@@ -99,4 +99,51 @@ describe('LocationComponent', () => {
       expect(component.form.get('zone_id')!.value).toBeNull();
     });
   });
+
+  describe('getLocation()', () => {
+    beforeEach(() => {
+      spyOn(navigator.geolocation, 'getCurrentPosition').and.callFake((cb: any) => {
+        cb({coords: {longitude: 11.25, latitude: 43.77}});
+      });
+    });
+
+    it('non produce errore spurio quando non esiste un marker precedente (Caso 2)', async () => {
+      store.overrideSelector(currentZone as any, null);
+      store.refreshState();
+
+      spyOn(store, 'dispatch').and.callFake((action: any) => {
+        if (action.type === '[Map] set current marker') {
+          store.overrideSelector(currentZone as any, mockZone);
+          store.refreshState();
+        }
+      });
+
+      await component.getLocation();
+
+      expect(component.form.get('location')!.errors).toBeNull();
+      expect(component.form.get('zone_id')!.value).toBe(42);
+    });
+
+    it('usa zone_id e city delle coordinate GPS nuove, non del marker precedente (Caso 1)', async () => {
+      const oldZone = {
+        type: 'Feature',
+        geometry: {coordinates: [], type: 'MultiPolygon'},
+        properties: {id: 99, comune: 'Vecchio', availableUserTypes: [], types: [], url: ''},
+      };
+      store.overrideSelector(currentZone as any, oldZone);
+      store.refreshState();
+
+      spyOn(store, 'dispatch').and.callFake((action: any) => {
+        if (action.type === '[Map] set current marker') {
+          store.overrideSelector(currentZone as any, mockZone);
+          store.refreshState();
+        }
+      });
+
+      await component.getLocation();
+
+      expect(component.form.get('zone_id')!.value).toBe(42);
+      expect(component.form.get('city')!.value).toBe('Firenze');
+    });
+  });
 });

--- a/projects/pap/src/app/shared/form/location/location.component.spec.ts
+++ b/projects/pap/src/app/shared/form/location/location.component.spec.ts
@@ -37,9 +37,7 @@ describe('LocationComponent', () => {
     store.refreshState();
 
     locationSpy = jasmine.createSpyObj('LocationService', ['getAddress']);
-    locationSpy.getAddress.and.returnValue(
-      of({address: 'Via Roma', house_number: '5', city: ''}),
-    );
+    locationSpy.getAddress.and.returnValue(of({address: 'Via Roma', house_number: '5', city: ''}));
 
     component = new LocationComponent(locationSpy, store as any, {detectChanges: () => {}} as any);
     component.form = buildParentForm();
@@ -81,7 +79,13 @@ describe('LocationComponent', () => {
 
   describe('setAddress() con indirizzo salvato', () => {
     it('should set zone_id from address.zone_id', () => {
-      component.setAddress({address: 'Via Verdi', city: 'Firenze', house_number: '3', id: 10, zone_id: 99});
+      component.setAddress({
+        address: 'Via Verdi',
+        city: 'Firenze',
+        house_number: '3',
+        id: 10,
+        zone_id: 99,
+      });
       expect(component.form.get('zone_id')!.value).toBe(99);
     });
 

--- a/projects/pap/src/app/shared/form/location/location.component.ts
+++ b/projects/pap/src/app/shared/form/location/location.component.ts
@@ -103,8 +103,8 @@ export class LocationComponent implements OnDestroy, ControlValueAccessor {
     try {
       navigator.geolocation.getCurrentPosition(location => {
         const coords = [location.coords.longitude, location.coords.latitude] as [number, number];
-        this.setPosition(coords);
         this._store.dispatch(setMarker({coords}));
+        this.setPosition(coords);
       });
     } catch (error) {
       console.error(error);

--- a/projects/pap/src/app/shared/form/state/company.selectors.spec.ts
+++ b/projects/pap/src/app/shared/form/state/company.selectors.spec.ts
@@ -11,6 +11,10 @@ import {FormJson, Properties} from '../model';
 declare const expect: (actual: any) => jasmine.Matchers<any>;
 
 describe('Company selectors', () => {
+  beforeEach(() => {
+    (selectCompanyProperties as any).clearResult();
+  });
+
   it('selectCompanyProperties should return properties', () => {
     const properties: Properties = {enableExludeInProgress: true};
     const companyState: CompanyState = {loading: false, properties};

--- a/projects/pap/src/app/shared/form/state/company.selectors.spec.ts
+++ b/projects/pap/src/app/shared/form/state/company.selectors.spec.ts
@@ -1,8 +1,4 @@
-import {
-  selectCompanyProperties,
-  selectFormJsonByStep,
-  selectLoading,
-} from './company.selectors';
+import {selectCompanyProperties, selectFormJsonByStep, selectLoading} from './company.selectors';
 import {CompanyState} from './company.reducer';
 import {FormJson, Properties} from '../model';
 
@@ -42,4 +38,3 @@ describe('Company selectors', () => {
     expect(selectLoading(rootState as any)).toBeFalse();
   });
 });
-


### PR DESCRIPTION
## Summary

- In `getLocation()`, `setPosition()` leggeva `currentZone$` con `take(1)` prima che `setMarker` fosse dispatchato: zona/comune errati se l'utente aveva già un marker precedente (Caso 1), errore spurio "posizione non valida" se nessun marker precedente (Caso 2)
- Fix: swap di 2 righe in `location.component.ts` — ordine ora allineato a `clickOnMap` in `map.component.ts`
- 2 test di regressione che falliscono se le righe vengono reinvertite (design con spy su `store.dispatch` per falsificare la race)
- Fix contestuale al selector pollution preesistente in `report-ticket.component.spec.ts` e `company.selectors.spec.ts` (esposto dai nuovi test)

## Test plan

- [ ] `npm run test:ci` — 59/59 SUCCESS verificato in locale
- [ ] Collaudo manuale: aprire una segnalazione, toccare la mappa in zona A, poi premere "usa la mia posizione" → verificare che zone_id e city siano aggiornati alle coordinate GPS reali
- [ ] Collaudo manuale Caso 2: aprire una segnalazione senza toccare la mappa, premere direttamente "usa la mia posizione" → verificare che il form non mostri errore "posizione non valida"

🤖 Generated with [Claude Code](https://claude.com/claude-code)